### PR TITLE
Remove num_decoder_symbols args

### DIFF
--- a/ntm.py
+++ b/ntm.py
@@ -132,7 +132,6 @@ class NTM(object):
                     loss = sequence_loss(logits=self.outputs[seq_length],
                                         targets=self.true_outputs[0:seq_length],
                                         weights=[1] * seq_length,
-                                        num_decoder_symbols=-1, # trash
                                         average_across_timesteps=False,
                                         average_across_batch=False,
                                         softmax_loss_function=\
@@ -188,7 +187,6 @@ class NTM(object):
             loss = sequence_loss(logits=self.outputs[seq_length],
                                 targets=self.true_outputs[0:seq_length],
                                 weights=[1] * seq_length,
-                                num_decoder_symbols=-1, # trash
                                 average_across_timesteps=False,
                                 average_across_batch=False,
                                 softmax_loss_function=\


### PR DESCRIPTION
That argument is unrecognized in the most recent version of TensorFlow
