### PR TITLE
Generalize task interface

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,2 +1,0 @@
-from copy import *
-from recall import *

--- a/tasks/copy.py
+++ b/tasks/copy.py
@@ -10,7 +10,8 @@ from ntm_cell import NTMCell
 
 print_interval = 5
 
-def copy(ntm, seq_length, sess, print_=True):
+
+def run(ntm, seq_length, sess, print_=True):
     start_symbol = np.zeros([ntm.cell.input_dim], dtype=np.float32)
     start_symbol[0] = 1
     end_symbol = np.zeros([ntm.cell.input_dim], dtype=np.float32)
@@ -54,7 +55,8 @@ def copy(ntm, seq_length, sess, print_=True):
     else:
         return seq, outputs, read_ws, write_ws, loss
 
-def copy_train(config, sess):
+
+def train(ntm, config, sess):
     if not os.path.isdir(config.checkpoint_dir):
         raise Exception(" [!] Directory %s not found" % config.checkpoint_dir)
 
@@ -63,13 +65,6 @@ def copy_train(config, sess):
     start_symbol[0] = 1
     end_symbol = np.zeros([config.input_dim], dtype=np.float32)
     end_symbol[1] = 1
-
-    cell = NTMCell(input_dim=config.input_dim,
-                   output_dim=config.output_dim,
-                   controller_layer_size=config.controller_layer_size,
-                   write_head_size=config.write_head_size,
-                   read_head_size=config.read_head_size)
-    ntm = NTM(cell, sess, config.min_length, config.max_length)
 
     print(" [*] Initialize all variables")
     tf.initialize_all_variables().run()
@@ -101,7 +96,7 @@ def copy_train(config, sess):
                 % (idx, seq_length, cost, time.time() - start_time))
 
     print("Training Copy task finished")
-    return cell, ntm
+
 
 def generate_copy_sequence(length, bits):
     seq = np.zeros([length, bits + 2], dtype=np.float32)

--- a/tasks/recall.py
+++ b/tasks/recall.py
@@ -10,7 +10,8 @@ from ntm_cell import NTMCell
 
 print_interval = 5
 
-def recall(ntm, seq_length, sess, print_=True):
+
+def run(ntm, seq_length, sess, print_=True):
     start_symbol = np.zeros([ntm.cell.input_dim], dtype=np.float32)
     start_symbol[0] = 1
     end_symbol = np.zeros([ntm.cell.input_dim], dtype=np.float32)
@@ -54,9 +55,8 @@ def recall(ntm, seq_length, sess, print_=True):
     else:
         return seq, outputs, read_ws, write_ws, loss
 
-def recall_train(config):
-    sess = config.sess
 
+def train(ntm, config, sess):
     if not os.path.isdir(config.checkpoint_dir):
         raise Exception(" [!] Directory %s not found" % config.checkpoint_dir)
 
@@ -64,13 +64,6 @@ def recall_train(config):
     start_symbol[0] = 1
     query_symbol = np.zeros([config.input_dim], dtype=np.float32)
     end_symbol[1] = 1
-
-    cell = NTMCell(input_dim=config.input_dim,
-                   output_dim=config.output_dim,
-                   controller_layer_size=config.controller_layer_size,
-                   write_head_size=config.write_head_size,
-                   read_head_size=config.read_head_size)
-    ntm = NTM(cell, sess, config.min_length, config.max_length)
 
     print(" [*] Initialize all variables")
     tf.initialize_all_variables().run()
@@ -102,7 +95,7 @@ def recall_train(config):
                 % (idx, seq_length, cost, time.time() - start_time))
 
     print("Training Copy task finished")
-    return cell, ntm
+
 
 def generate_recall_sequence(num_items, item_length, input_dim):
     items = []


### PR DESCRIPTION
Tasks will have uniformed interface with this patch.
1. You don't need to add import lines under tasks/**init**.py
2. Each task will have `train` and `run` instead of `train_copy` and `copy`.
3. NTM initialization also will be unified in main.
